### PR TITLE
fix put and delete console routes

### DIFF
--- a/src/index.yml
+++ b/src/index.yml
@@ -8,6 +8,8 @@ paths:
     $ref: ./routes/ping.yml#/ping
   /consoles:
     $ref: ./routes/console.yml#/consoles
+  /consoles/{consoleName}:
+    $ref: ./routes/console.yml#/console
   /consoles/{consoleName}/pages:
     $ref: ./routes/page.yml#/pages
   /consoles/{consoleName}/pages/{pageId}:

--- a/src/routes/console.yml
+++ b/src/routes/console.yml
@@ -48,6 +48,7 @@ consoles:
               $ref: '../schemas/console.yml#/Console'
       default:
         $ref: '../shared-responses/index.yml#/TinyStacksError'
+console:
   put:
     operationId: updateConsole
     tags:


### PR DESCRIPTION
declare `/consoles/{consoleName}` for put and delete console
necessary for proper path param resolution