### PR TITLE
publish all json schemas

### DIFF
--- a/scripts/transpile-json-schema.js
+++ b/scripts/transpile-json-schema.js
@@ -3,7 +3,34 @@ const fs = require('fs');
 const yaml = require('js-yaml');
 const { resolveRefsAt } = require('json-refs');
 
-async function transpileJsonSchema () {
+async function transpileSchema (filePath) {
+  const pathElems = filePath.split('/');
+  const fileName = pathElems.at(-1);
+  const jsonFileName = fileName.replace('.yml', '.json');
+  const refResolvedSchema = await resolveRefsAt(path.resolve(filePath),  {
+    loaderOptions : {
+      processContent: (res, callback) => {
+        callback(null, yaml.load(res.text));
+      }
+    }
+  });
+
+  fs.writeFileSync(`dist/json-schemas/${jsonFileName}`, JSON.stringify(refResolvedSchema.resolved, null, 2));
+}
+
+async function transpileJsonSchemas () {
+  const schemas = [
+    'src/schemas/yaml-provider.yml',
+    'src/schemas/yaml-widget.yml',
+    'src/schemas/yaml-dashboard.yml',
+    'src/schemas/config.yml'
+  ];
+  
+  fs.mkdirSync('dist/json-schemas', { recursive: true });
+  for (const schema of schemas) {
+    await transpileSchema(schema);
+  }
+
   const refResolvedSchema = await resolveRefsAt(path.resolve('src/schemas/config.yml'),  {
     loaderOptions : {
       processContent: (res, callback) => {
@@ -12,6 +39,6 @@ async function transpileJsonSchema () {
     }
   });
 
-  fs.writeFileSync('dist/config-schema.json', JSON.stringify(refResolvedSchema.resolved.Config, null, 2));
+  fs.writeFileSync(`dist/json-schemas/index.json`, JSON.stringify(refResolvedSchema.resolved.Config, null, 2));
 }
-transpileJsonSchema();
+transpileJsonSchemas();

--- a/src/schemas/config.yml
+++ b/src/schemas/config.yml
@@ -9,7 +9,7 @@ Config:
         providers:
           type: object
           additionalProperties:
-            $ref: './provider.yml#/Provider'
+            $ref: './yaml-provider.yml#/YamlProvider'
         dependencies:
           type: object
           additionalProperties:


### PR DESCRIPTION
Since we have circular references in our schemas, we need to publish all individual schemas that are used for reference and validation in other places.