### PR TITLE
Enhanced TinyStacksError Model

### DIFF
--- a/src/schemas/tinystacks-error.yml
+++ b/src/schemas/tinystacks-error.yml
@@ -4,18 +4,37 @@ TinyStacksError:
     name:
       type: string
       default: TinyStacksError
+      description: The standard name of a TinyStacksError; always to be set to TinyStacksError.
     message:
       type: string
+      description: A concise message describing the error in more detail than the status code.
     status:
       type: number
+      description: The standard HTTP status code for the error.  Be sure to use the most specific error code possible, falling back to the X00 codes as necessary.  See https://developer.mozilla.org/en-US/docs/Web/HTTP/Status for more details.
     stack:
       type: string
+      description: The stack trace of the error.  This is typically not shown to the client, but is important for server-side logging and debugging.
     cause:
       type: string
+      description: Used to describe the origin of an error if that original error has meaning to the client.  This field should add specificity to 'message'.
+    fields:
+      type: object
+      description: Used to identify specific fields in a JSON body that caused the error.  Typically only used for 4xx type responses.  The key should be the json path to the invalid property and the value should be an error message specific to that property.
+      additionalProperties:
+        type: string
     context:
       type: string
+      description: Used to identify what part of the request caused the error for non-JSON payloads.
     type:
-      $ref: '#/TinyStacksErrorTypeEnum'
+      description: A standard error type corresponding to the textual representation of an HTTP status code.  See https://www.npmjs.com/package/http-status-codes for status codes not included in our default list.
+      anyOf:
+        - $ref: '#/TinyStacksErrorTypeEnum'
+        - type: string
+  required:
+    - name
+    - message
+    - status
+    - type
 TinyStacksErrorTypeEnum:
   type: string
   enum:

--- a/src/schemas/tinystacks-error.yml
+++ b/src/schemas/tinystacks-error.yml
@@ -10,6 +10,10 @@ TinyStacksError:
       type: number
     stack:
       type: string
+    cause:
+      type: string
+    context:
+      type: string
     type:
       $ref: '#/TinyStacksErrorTypeEnum'
 TinyStacksErrorTypeEnum:


### PR DESCRIPTION
In order to communicate more information back to the client we are adding additional fields beyond message and stack.  This allows the aforementioned properties to keep their current significance while sending additional contextual information.

This PR adds the following optional properties to the TinyStacksError model:
1. cause
    - This field should be used to describe the origin of an error if that original error has meaning to the user. Typically this is most useful for 4xx types where the user needs to correct something in their request.
2. context
    - This property should be used to identify what part of the request likely caused the error for non-JSON request bodies.   Typically only used for 4xx type errors.
3. fields
    - This property should be used to identify what part of aJSON request body cause the error.  Typically only used for 4xx type errors.

This PR also adds descriptions to the TinyStacksError properties that will manifest as tsdoc comments and intellisense.